### PR TITLE
phpmd: added rulesets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,9 @@
         "phpstan": "phpstan -ctests/PhpStan/phpstan.neon analyse src/",
         "phpstan-report": "phpstan -ctests/PhpStan/phpstan.neon analyse src/ --error-format=json > phpstan.report.json",
 
-        "phpmd": "phpmd src text cleancode,codesize,design,naming,unusedcode",
-        "phpmd-report": "phpmd src json cleancode,codesize,design,naming,unusedcode --reportfile phpmd.report.json",
+        "phpmd": "phpmd src ansi tests/PhpMd/standard.xml",
+        "phpmd-excludestaticaccess": "phpmd src ansi tests/PhpMd/exclude-static-access-rule.xml",
+        "phpmd-report": "phpmd src json tests/PhpMd/standard.xml --reportfile tests/reports/phpmd.report.json",
 
         "static": [
             "@phpcs",

--- a/tests/PhpMd/exclude-static-access-rule.xml
+++ b/tests/PhpMd/exclude-static-access-rule.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<ruleset name="Exclude Static Access Rule"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
+                     http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="
+                     http://pmd.sf.net/ruleset_xml_schema.xsd"
+        rule="Tests/PhpMd/standard.xml">
+    <description>
+        Exclude Static Access Rule
+    </description>
+    <rule ref="rulesets/codesize.xml" />
+    <rule ref="rulesets/design.xml" />
+    <rule ref="rulesets/naming.xml" />
+    <rule ref="rulesets/unusedcode.xml" />
+    <rule ref="rulesets/controversial.xml" />
+    <rule ref="rulesets/cleancode.xml">
+        <exclude name="StaticAccess" />
+    </rule>
+</ruleset>

--- a/tests/PhpMd/exclude-static-access-rule.xml
+++ b/tests/PhpMd/exclude-static-access-rule.xml
@@ -14,7 +14,6 @@
     <rule ref="rulesets/design.xml" />
     <rule ref="rulesets/naming.xml" />
     <rule ref="rulesets/unusedcode.xml" />
-    <rule ref="rulesets/controversial.xml" />
     <rule ref="rulesets/cleancode.xml">
         <exclude name="StaticAccess" />
     </rule>

--- a/tests/PhpMd/standard.xml
+++ b/tests/PhpMd/standard.xml
@@ -14,6 +14,5 @@
     <rule ref="rulesets/design.xml" />
     <rule ref="rulesets/naming.xml" />
     <rule ref="rulesets/unusedcode.xml" />
-    <rule ref="rulesets/controversial.xml" />
     <rule ref="rulesets/cleancode.xml" />
 </ruleset>

--- a/tests/PhpMd/standard.xml
+++ b/tests/PhpMd/standard.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<ruleset name="Standard PHPMD rule set for Oxid"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
+                     http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="
+                     http://pmd.sf.net/ruleset_xml_schema.xsd">
+    <description>
+        Standard OXID Ruleset
+    </description>
+
+    <rule ref="rulesets/codesize.xml" />
+    <rule ref="rulesets/design.xml" />
+    <rule ref="rulesets/naming.xml" />
+    <rule ref="rulesets/unusedcode.xml" />
+    <rule ref="rulesets/controversial.xml" />
+    <rule ref="rulesets/cleancode.xml" />
+</ruleset>


### PR DESCRIPTION
phpmd: added rulesets
phpmd: changed output format to "ansi" for better readability
phpmd: changed report path to "tests/reports" which is in the gitignore file


I've changed the outputformat from "text" to "ansi" for better readability.
I've added standard rule sets for phpmd for an easier project setup.

~~The ruleset includes the "controversial" rules.
They are basically only about using CamelCase for naming classes, methods, and attributes
https://phpmd.org/rules/controversial.html
It will complain about underscore prefixes, but they are deprecated anyway.
If you would like to avoid this, please remove line 17 in tests/PhpMd/exclude-static-access-rule.xml and tests/PhpMd/standard.xml~~
(see comment below)

Exclude Static Access rule:
We are using many static accesses in modules like `Registry::getSession()`.
We should keep an eye on it and fix it in the future (like Oxid 7), that's why it is in the standard ruleset, 
but you can call `composer phpmd-excludestaticaccess` to have a clean overview about all other violations.