### PR TITLE
Update workflows

### DIFF
--- a/tests/github_actions/module-template.yml
+++ b/tests/github_actions/module-template.yml
@@ -1,3 +1,7 @@
+prepare_shop:
+  git:
+    shop_ref: '{{ .Data.global.git.default_ref }}'
+
 # {{ $ids := "oe_moduletemplate" }}ids: {{ print $ids }}
 # {{ $org := "oxid-esales" }}organisation: {{ print $org }}
 # {{ $name := "module-template" }}name: {{ print $name }}


### PR DESCRIPTION
## Issue
The github workflows are not working properly, when handling pull requests due to the branch "merge/<whatever_number>" not being available in the shop repository but only in this repository.

## Description
In the defaults, the branch, we are pulling for the shop is set to "the current branch" which is correct for the shop but not for modules, where we might have a branch "b-7.0.x-feature-foo" which should use the shop "b-7.0.x" until told otherwise. This fixes it to always take the "default_ref", which is 8.0.x by default or '7.0.x' when using the tests/github_actions/defaults/7.0.x.yml template and 7.1.x when using the tests/github_actions/defaults/7.1.x.yml template.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)